### PR TITLE
Upgrade to Polymer 1.8 hybrid component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,6 @@
     "/demo/"
   ],
   "dependencies": {
-    "polymer": "^2.0.0"
+    "polymer": "^1.8.0"
   }
 }


### PR DESCRIPTION
No real changes, just the version bump.

I'd initially bumped to 2.0.0 and released that, but we don't want to do that just yet, so I'll merge this then delete the 2.0.0 tag before it's used anywhere.