### PR TITLE
US89544 - Allow srcset URLs to optionally include date time stampsin …

### DIFF
--- a/d2l-organization-hm-behavior.html
+++ b/d2l-organization-hm-behavior.html
@@ -11,7 +11,7 @@
 	* @polymerBehavior window.D2L.Hypermedia.OrganizationHMBehavior
 	*/
 	window.D2L.Hypermedia.OrganizationHMBehavior = {
-		getImageSrcset: function(image, imageClass) {
+		getImageSrcset: function(image, imageClass, forceImageRefresh) {
 			if (!image) { return ''; }
 			var srcset = '',
 				sizes = this._getImageLinks(image, imageClass),
@@ -25,10 +25,11 @@
 						highMin: 640, highMid: 750, highMax: 1534
 					}
 				},
-				selectedWidths = imageWidths[imageClass] || imageWidths.narrow;
+				selectedWidths = imageWidths[imageClass] || imageWidths.narrow,
+				dateTimeString = forceImageRefresh ? '#' + new Date().getTime() : '';
 
 			['lowMin', 'lowMid', 'lowMax', 'highMin', 'highMid', 'highMax'].forEach(function(size) {
-				srcset += sizes[size] ? sizes[size] + ' ' + selectedWidths[size] + 'w, ' : '';
+				srcset += sizes[size] ? sizes[size] + dateTimeString + ' ' + selectedWidths[size] + 'w, ' : '';
 			});
 			return srcset.replace(/,\s*$/, '');
 		},

--- a/test/d2l-organization-hm-behavior.js
+++ b/test/d2l-organization-hm-behavior.js
@@ -92,5 +92,9 @@ describe('d2l-organization-hm-behavior', function() {
 			var link = component.getImageSrcset(imageEntity, 'narrow');
 			expect(link).to.equal('http://image.com/banner-narrow-low-density-max 767w, http://image.com/banner-narrow-high-density-max 1534w');
 		});
+		it('should return a banner srcset with date timestamp when forceImageRefresh true', function() {
+			var link = component.getImageSrcset(imageEntity, 'narrow', true);
+			expect(link.search('http://image.com/banner-narrow-low-density-max#[0-9]{13}')).to.equal(0);
+		});
 	});
 });


### PR DESCRIPTION
…order to force browser to refresh images

This is similar to the change made for banner image.  Basically this 'tricks' the browser into not using local memory cache when the URL for an image otherwise seems the same to it.  We only do this sometimes as most often allowing the browser to "do its thing" is a good idea.  It is a problem though when uploading an image to the LMS, as the URL for the course image doesn't really change for most srcset images.

The #datetimestamp solution seems to work quite well and doesn't muck with anything server-side AFAIK which is good.