### PR TITLE
US92183 Remove window from behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ bower install git://github.com/Brightspace/organization-hm-behavior.git#v0.0.1
 ## Usage
 ```js
 behaviors: [
-	D2L.Hypermedia.OrganizationHMBehavior
+	D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior
 ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ bower install git://github.com/Brightspace/organization-hm-behavior.git#v0.0.1
 ## Usage
 ```js
 behaviors: [
-	window.D2L.Hypermedia.OrganizationHMBehavior
+	D2L.Hypermedia.OrganizationHMBehavior
 ],
 ```
 

--- a/d2l-organization-hm-behavior.html
+++ b/d2l-organization-hm-behavior.html
@@ -6,9 +6,9 @@
 
 	/*
 	* General utility functions for parsing organization siren entities.
-	* @polymerBehavior window.D2L.Hypermedia.OrganizationHMBehavior
+	* @polymerBehavior D2L.Hypermedia.OrganizationHMBehavior
 	*/
-	window.D2L.Hypermedia.OrganizationHMBehavior = {
+	D2L.Hypermedia.OrganizationHMBehavior = {
 		getImageSrcset: function(image, imageClass, forceImageRefresh) {
 			if (!image) { return ''; }
 			var srcset = '',

--- a/d2l-organization-hm-behavior.html
+++ b/d2l-organization-hm-behavior.html
@@ -2,13 +2,14 @@
 	'use strict';
 
 	window.D2L = window.D2L || {};
-	window.D2L.Hypermedia = window.D2L.Hypermedia || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.Hypermedia = window.D2L.PolymerBehaviors.Hypermedia || {};
 
 	/*
 	* General utility functions for parsing organization siren entities.
-	* @polymerBehavior D2L.Hypermedia.OrganizationHMBehavior
+	* @polymerBehavior D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior
 	*/
-	D2L.Hypermedia.OrganizationHMBehavior = {
+	D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior = {
 		getImageSrcset: function(image, imageClass, forceImageRefresh) {
 			if (!image) { return ''; }
 			var srcset = '',

--- a/test/consumer-element.html
+++ b/test/consumer-element.html
@@ -8,7 +8,7 @@
 		Polymer({
 			is: 'consumer-element',
 			behaviors: [
-				D2L.Hypermedia.OrganizationHMBehavior
+				D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior
 			]
 		});
 	</script>

--- a/test/consumer-element.html
+++ b/test/consumer-element.html
@@ -8,7 +8,7 @@
 		Polymer({
 			is: 'consumer-element',
 			behaviors: [
-				window.D2L.Hypermedia.OrganizationHMBehavior
+				D2L.Hypermedia.OrganizationHMBehavior
 			]
 		});
 	</script>


### PR DESCRIPTION
I've seen Dave doing this in his cleanup steps, but this will cause the previous PR to be a breaking change and there's a few repos that use it other than `course-image`.  I don't think the other PR is breaking right now, but let me know if I'm missing something.

Not sure which is preferred: 
- To make the previous change a minor version and this a major version change
- Just merge this into the other PR and make that a major version change
- Not worry about this right now