### PR TITLE
Use siren-parser-import in favour of CDN script

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
   ],
   "devDependencies": {
     "web-component-tester": "^6.0.0",
-    "polymer": "^2.3.1"
+    "polymer": "^2.3.1",
+    "siren-parser-import": "Brightspace/siren-parser-import#^6.5.0"
   }
 }

--- a/test/d2l-organization-hm-behavior.html
+++ b/test/d2l-organization-hm-behavior.html
@@ -5,9 +5,9 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../web-component-tester/browser.js"></script>
-		<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 
 		<link rel="import" href="consumer-element.html">
+		<link rel="import" href="../../siren-parser-import/siren-parser.html">
 	</head>
 	<body>
 		<test-fixture id="default-fixture">

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-		<script src="../node_modules/web-component-tester/browser.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
 	</head>
 	<body>
 		<script>


### PR DESCRIPTION
Only used in tests here, but one less usage of the CDN script is good.