### PR TITLE
Require hydrated entities

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,1 @@
+*	@ryantmer

--- a/d2l-organization-hm-behavior.html
+++ b/d2l-organization-hm-behavior.html
@@ -10,8 +10,19 @@
 	* @polymerBehavior D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior
 	*/
 	D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior = {
+		/**
+		 * Creates a `srcset` string from a Siren organization-image entity to
+		 * be used with an <img> tag.
+		 * @param {Entity} image Siren organization image entity. Must be a hydrated entity (not a linked entity).
+		 * @param {string} imageClass Class used to find correct organization image links. Defaults to `tile`.
+		 * @param {bool} forceImageRefresh If true, generated URLs will include a cache-busting timestamp
+		 * @return {string} `srcset` to be used with an <img> tag.
+		 */
 		getImageSrcset: function(image, imageClass, forceImageRefresh) {
-			if (!image) { return ''; }
+			if (!image || image.href) {
+				return;
+			}
+
 			var srcset = '',
 				separator,
 				forceRefreshParam = '',
@@ -40,9 +51,16 @@
 			});
 			return srcset.replace(/,\s*$/, '');
 		},
-		// Returns the best available image to use as a default
+		/**
+		 * Gets the link to the image entity with the given `imageClass` class
+		 * Defaults to the image entity with the `tile` class if `imageClass`
+		 * is not provided.
+		 * @param {Entity} image Siren organization-image entity. Must be a hydrated entity (not a linked entity).
+		 * @param {string} imageClass Class used to find correct organization image link. Defaults to `tile`.
+		 * @return {string} URL of image with the requested `imageClass`.
+		 */
 		getDefaultImageLink: function(image, imageClass) {
-			if (!image) {
+			if (!image || image.href) {
 				return;
 			}
 

--- a/test/d2l-organization-hm-behavior.js
+++ b/test/d2l-organization-hm-behavior.js
@@ -59,16 +59,27 @@ describe('d2l-organization-hm-behavior', function() {
 				}
 			]
 		},
+		imageLinked = {
+			rel: ['https://api.brightspace.com/rels/organization-image'],
+			href: 'http://image.com/some-image'
+		},
 		imageEntity,
-		imageLowdEntity;
+		imageLowdEntity,
+		imageLinkedEntity;
 
 	beforeEach(function() {
 		component = fixture('default-fixture');
 		imageEntity = window.D2L.Hypermedia.Siren.Parse(image);
 		imageLowdEntity = window.D2L.Hypermedia.Siren.Parse(imageLowd);
+		imageLinkedEntity = window.D2L.Hypermedia.Siren.Parse({ entities: [imageLinked] })
+			.getSubEntityByRel('https://api.brightspace.com/rels/organization-image');
 	});
 
 	describe('getDefaultImageLink', function() {
+		it('should return undefined if a linked entity is passed in', function() {
+			var link = component.getDefaultImageLink(imageLinkedEntity);
+			expect(link).to.be.undefined;
+		});
 		it('should return high-density max image as a default image', function() {
 			var link = component.getDefaultImageLink(imageEntity, 'tile');
 			expect(link).to.equal(image.links[1].href);
@@ -84,6 +95,10 @@ describe('d2l-organization-hm-behavior', function() {
 	});
 
 	describe('getImageSrcset', function() {
+		it('should return undefined if a linked entity is passed in', function() {
+			var link = component.getImageSrcset(imageLinkedEntity);
+			expect(link).to.be.undefined;
+		});
 		it('should return a tile srcset based on the links available', function() {
 			var link = component.getImageSrcset(imageEntity, 'tile');
 			expect(link).to.equal('http://image.com/tile-low-density-max 540w, http://image.com/tile-high-density-max 1080w');


### PR DESCRIPTION
The existing implementation doesn't work with linked entities, but there isn't really an explicit mention of this, nor are we explicitly checking for it. Added docstrings to make this clearer, and also added a check for `image.href` to both `getImageSrcset` and `getDefaultImageLink`. This leaves it up to the consumer to fetch and hydrate the organization-image entity rather than handling it here.

Going to release this as a patch for two reasons:

1. All current usages that would have broken with the new method would have broken with the old method anyway
2. `srcset` (returned by `getImageSrcset`) is an attribute, which is stringified anyway - whether it's "" (old) or "undefined" (new), it will have the same result of a 404

Contributes to fixing https://github.com/Brightspace/d2l-my-courses-ui/issues/507.